### PR TITLE
Fix: responsive images on small screens

### DIFF
--- a/Interfaces/Website/ArabicImageCaptioning/index.css
+++ b/Interfaces/Website/ArabicImageCaptioning/index.css
@@ -1,5 +1,9 @@
 @import url("https://fonts.googleapis.com/css?family=Amiri&display=swap");
 
+img {
+  max-width: 100%;
+  object-fit: contain;
+}
 #maincontainer::before {
   background-image: url("arabic-letters-full.png");
   background-size: cover;

--- a/Interfaces/Website/ArabicImageCaptioning/index.html
+++ b/Interfaces/Website/ArabicImageCaptioning/index.html
@@ -47,7 +47,7 @@
         الرجاء الانتظار لتهيئة النموذج
       </div>
       <div class="inputs text-center collapse" id = "inputs">
-          <img id = "img" width = "512px" height = "512px" src = "images/girrafe.jpg"/>
+          <img id = "img" src = "images/girrafe.jpg"/>
           <br>
           <input type="file" class = "btn btn-dark btn-sm preview collapse">
 

--- a/Interfaces/Website/ArabicTextDetection/index.css
+++ b/Interfaces/Website/ArabicTextDetection/index.css
@@ -1,5 +1,9 @@
 @import url("https://fonts.googleapis.com/css?family=Amiri&display=swap");
 
+canvas {
+  max-width: 100%;
+  object-fit: contain;
+}
 #maincontainer::before {
   background-image: url("arabic-letters-full.png");
   background-size: cover;

--- a/Interfaces/Website/ObjectDetection/index.css
+++ b/Interfaces/Website/ObjectDetection/index.css
@@ -1,5 +1,9 @@
 @import url("https://fonts.googleapis.com/css?family=Amiri&display=swap");
 
+canvas {
+  max-width: 100%;
+  object-fit: contain;
+}
 #maincontainer::before {
   background-image: url("arabic-letters-full.png");
   background-size: cover;


### PR DESCRIPTION
Some images are not displayed correctly on small screens.

## Before fix:

- https://arbml.github.io/ARBML/Interfaces/Website/ObjectDetection/index.html
- https://arbml.github.io/ARBML/Interfaces/Website/ArabicTextDetection/index.html
- https://arbml.github.io/ARBML/Interfaces/Website/ArabicImageCaptioning/index.html

<img width="250" alt="image" src="https://user-images.githubusercontent.com/8544289/215295520-a407ee10-9461-4d35-bad2-170446527078.png"> , <img width="200" alt="image" src="https://user-images.githubusercontent.com/8544289/215295540-b796bb3f-fa49-45dc-8694-587b0d093096.png">  , <img width="200" alt="image" src="https://user-images.githubusercontent.com/8544289/215295555-59e3dca9-b6a8-4e9a-8cce-8d634d198174.png">

## After fix:

- https://forzagreen.github.io/ARBML/Interfaces/Website/ObjectDetection/index.html
- https://forzagreen.github.io/ARBML/Interfaces/Website/ArabicTextDetection/index.html
- https://forzagreen.github.io/ARBML/Interfaces/Website/ArabicImageCaptioning/index.html

<img width="200" alt="image" src="https://user-images.githubusercontent.com/8544289/215295765-cc3b9870-87a8-4c6b-ad1b-089766572a83.png"> , <img width="200" alt="image" src="https://user-images.githubusercontent.com/8544289/215295751-c50b54da-7cd6-43e3-bfda-da44a909e8ad.png"> , <img width="200" alt="image" src="https://user-images.githubusercontent.com/8544289/215295772-0364c7d9-aa02-48c9-a701-3db1c5f47d03.png">



